### PR TITLE
Added ROBB Zigbee smart plug device ROB_200-017-0

### DIFF
--- a/profile_library/ROBB/ROB_200-017-0/model.json
+++ b/profile_library/ROBB/ROB_200-017-0/model.json
@@ -1,0 +1,17 @@
+{
+	"measure_description": "Manually measured average of 2 plugs",
+	"measure_method": "manual",
+	"measure_device": "Brennenstuhl PM 231 E",
+	"name": "ROBB Zigbee Smart Plug",
+	"standby_power": 0.2,
+	"sensor_config": {
+		"power_sensor_naming": "{} Device Power",
+		"energy_sensor_naming": "{} Device Energy"
+	},
+	"device_type": "smart_switch",
+	"calculation_strategy": "fixed",
+	"fixed_config": {
+		"power": 0.65
+	},
+	"created_at": "2024-05-07T20:30:00"
+}

--- a/profile_library/ROBB/ROB_200-017-0/model.json
+++ b/profile_library/ROBB/ROB_200-017-0/model.json
@@ -1,17 +1,17 @@
 {
-	"measure_description": "Manually measured average of 2 plugs",
-	"measure_method": "manual",
-	"measure_device": "Brennenstuhl PM 231 E",
-	"name": "ROBB Zigbee Smart Plug",
-	"standby_power": 0.2,
-	"sensor_config": {
-		"power_sensor_naming": "{} Device Power",
-		"energy_sensor_naming": "{} Device Energy"
-	},
-	"device_type": "smart_switch",
-	"calculation_strategy": "fixed",
-	"fixed_config": {
-		"power": 0.65
-	},
-	"created_at": "2024-05-07T20:30:00"
+  "measure_description": "Manually measured average of 2 plugs",
+  "measure_method": "manual",
+  "measure_device": "Brennenstuhl PM 231 E",
+  "name": "ROBB Zigbee Smart Plug",
+  "standby_power": 0.2,
+  "sensor_config": {
+    "power_sensor_naming": "{} Device Power",
+    "energy_sensor_naming": "{} Device Energy"
+  },
+  "device_type": "smart_switch",
+  "calculation_strategy": "fixed",
+  "fixed_config": {
+    "power": 0.65
+  },
+  "created_at": "2024-05-07T20:30:00"
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Device information
<!--
  Provide and links and additional information about the device you are adding in this PR.
-->
ROBB Zigbee smart plug ROB_200-017-0, [zigbee2mqtt](https://www.zigbee2mqtt.io/devices/ROB_200-017-0.html) and [vendor website](https://www.robbshop.nl/robb-smarrt-slimme-stekker-zigbee-3680w). EAN 7439647749714

## Home Assistant Device information
<!--
  Provide the Home Assistant device information. This can be found on the device page in HA, on the top left under `Device Info`.
  Please paste that information here.
-->
```
Device info
ROB_200-017-0
by ROBB smarrt
Connected via dresden elektronik Conbee II
Firmware: 0x00000008
Zigbee info

IEEE: 90:35:ea:ff:fe:xx:xx:xx
Nwk: 0x0673
Device Type: Router
LQI: 255
RSSI: -29
Last seen: 2024-05-07T20:51:26
Power source: Mains
```

## Checklist
<!--
  Please check all the boxes when applicable.
-->

- [x] I have created a single PR per device. When you have multiple submissions please create separate PR's.
- [ ] For lights - I have only included the gzipped files (*.gz), not the raw CSV files.
- [ ] For lights - I have provided a CSV file per supported color mode. Look that up in Developer Tools -> States

## Additional info
<!--
  Add any additional info we must know about the measurements here.
-->
Measured average of 2 devices.